### PR TITLE
pass appcleaner version as class parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,9 +1,11 @@
 # Public: Install AppCleaner to /Applications.
 #
 # include appcleaner
-class appcleaner {
+class appcleaner(
+  $version = '2.2.3'
+) {
   package { 'AppCleaner':
     provider => 'compressed_app',
-    source => 'http://www.freemacsoft.net/downloads/AppCleaner_2.1.zip',
+    source => "http://www.freemacsoft.net/downloads/AppCleaner_${version}.zip",
   }
 }


### PR DESCRIPTION
Allow to override AppCleaner version using Hiera without modification
to the puppet-appcleaner module, when version is updated on website.
